### PR TITLE
Update view paths in DashBoardController

### DIFF
--- a/PizzarIO_SWP391/src/main/java/com/group1/swp/pizzario_swp391/controller/DashBoardController.java
+++ b/PizzarIO_SWP391/src/main/java/com/group1/swp/pizzario_swp391/controller/DashBoardController.java
@@ -10,12 +10,12 @@ public class DashBoardController {
 
     @GetMapping("/analytics")
     public String getFormAnalytics(){
-        return "analytics";
+        return "admin_page/analytics";
     }
 
     @GetMapping("/shifts")
     public String getFormShift(){
-        return "shift_management";
+        return "admin_page/shift_management";
     }
 
 }


### PR DESCRIPTION
Changed the return values of getFormAnalytics and getFormShift to use the 'admin_page/' prefix, updating the view paths for analytics and shift management pages.